### PR TITLE
Increase text size for login/register switch

### DIFF
--- a/Gadgeothek/app/src/main/res/layout/activity_login.xml
+++ b/Gadgeothek/app/src/main/res/layout/activity_login.xml
@@ -114,7 +114,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="bottom"
             android:gravity="center"
-            android:text="Noch kein Konto? Registriere dich hier!" />
+            android:text="Noch kein Konto? Registriere dich hier!"
+            android:textSize="20sp" />
 
     </LinearLayout>
 

--- a/Gadgeothek/app/src/main/res/layout/activity_register.xml
+++ b/Gadgeothek/app/src/main/res/layout/activity_register.xml
@@ -131,7 +131,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="Schon einen Account? Log dich ein!" />
+            android:text="Schon einen Account? Log dich ein!"
+            android:textSize="20sp" />
 
     </LinearLayout>
 


### PR DESCRIPTION
before:

![vorher](https://user-images.githubusercontent.com/625793/31884044-2b92af96-b7ec-11e7-93ab-93e9fb80f9b5.png)

after:

![nachher](https://user-images.githubusercontent.com/625793/31884053-31ab2836-b7ec-11e7-9f67-c07fe34d47e3.png)

Seems easier to touch with a finger that way :wink: